### PR TITLE
Minor improvements and removed clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,24 +50,31 @@ pub struct KeyNotFoundError;
 /// holds arbitrary values, uses string keys
 /// common slices of stored keys are compressed by
 /// not storing duplicates of those common slices.
-#[derive(Debug, Default, PartialEq, Eq)]
-pub struct Trie<K: Eq + Clone + Default, V> {
+#[derive(Debug, PartialEq, Eq)]
+pub struct Trie<K: Eq + Clone, V> {
     /// tree root
     /// this will always be a node with the empty string.
     root: TrieNode<K, V>,
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
-struct TrieNode<K: Eq + Clone + Default, V> {
+#[derive(Debug, PartialEq, Eq)]
+struct TrieNode<K: Eq + Clone, V> {
     children: Vec<TrieNode<K, V>>,
     value: Option<V>,
     prefix: Box<[K]>,
 }
 
-impl<K: Eq + Clone + Default, V: Default> Trie<K, V> {
+impl<K: Eq + Clone, V> Trie<K, V> {
     /// constructs an empty prefix tree
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Default::default()
+        Trie {
+            root: TrieNode {
+                value: None,
+                prefix: Box::new([]),
+                children: Vec::new(),
+            },
+        }
     }
 
     /// gets the value of a key
@@ -126,7 +133,7 @@ impl<K: Eq + Clone + Default, V: Default> Trie<K, V> {
     }
 }
 
-impl<V: Default> Trie<u8, V> {
+impl<V> Trie<u8, V> {
     /// Puts a value in with a certain string key.
     /// The old value is ejected if it exists.
     pub fn put_str(&mut self, key: &str, val: V) -> Option<V> {
@@ -160,7 +167,7 @@ impl<V: Default> Trie<u8, V> {
     }
 }
 
-impl<K: Eq + Clone + Default, V: Default> TrieNode<K, V> {
+impl<K: Eq + Clone, V> TrieNode<K, V> {
     fn size(&self) -> usize {
         let mut size = 1;
         for other in self.children.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ struct TrieNode<K: Eq + Clone, V> {
 
 impl<K: Eq + Clone, V> Trie<K, V> {
     /// constructs an empty prefix tree
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Trie {
             root: TrieNode {
@@ -164,6 +163,12 @@ impl<V> Trie<u8, V> {
     /// Removes a given string key from the Trie.
     pub fn remove_str(&mut self, key: &str) -> Result<V, KeyNotFoundError> {
         self.remove(key.as_bytes())
+    }
+}
+
+impl<K: Eq + Clone, V> Default for Trie<K, V> {
+    fn default() -> Self {
+        Trie::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,20 +6,20 @@
  *
  * It is recommended to use static sized numbers or strings. Use `u8` if
  * string keys are being used.
- * 
+ *
  * Using the Trie with strings requires using the designated string
- * functions; this will automatically turn the string into a slice of 
+ * functions; this will automatically turn the string into a slice of
  * u8's which is compatible with the tree. Unicode equivalency is not
  * checked.
- * 
+ *
  * It is not recommended to use the Trie with large structs as the key,
  * as performance will suffer due to the key being cloned into the prefix
  * tree, as opposed to referenced or taken into ownership.
- * 
+ *
  * Some unimplemented todos include:
  * - Add support for iteration
  * - Add support for in-place iteration, without IntoIter
- * 
+ *
  * In-place iteration without requiring the usage of Rc's or unsafe will likely be difficult due to the
  * tree's unidirectional nature.
  */
@@ -50,30 +50,24 @@ pub struct KeyNotFoundError;
 /// holds arbitrary values, uses string keys
 /// common slices of stored keys are compressed by
 /// not storing duplicates of those common slices.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Trie<K: Eq + Clone, V> {
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Trie<K: Eq + Clone + Default, V> {
     /// tree root
     /// this will always be a node with the empty string.
     root: TrieNode<K, V>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-struct TrieNode<K: Eq + Clone, V> {
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TrieNode<K: Eq + Clone + Default, V> {
     children: Vec<TrieNode<K, V>>,
     value: Option<V>,
     prefix: Box<[K]>,
 }
 
-impl<K: Eq + Clone, V> Trie<K, V> {
+impl<K: Eq + Clone + Default, V: Default> Trie<K, V> {
     /// constructs an empty prefix tree
     pub fn new() -> Self {
-        Trie {
-            root: TrieNode {
-                value: None,
-                prefix: Box::new([]),
-                children: Vec::new(),
-            },
-        }
+        Default::default()
     }
 
     /// gets the value of a key
@@ -132,7 +126,7 @@ impl<K: Eq + Clone, V> Trie<K, V> {
     }
 }
 
-impl<V> Trie<u8, V> {
+impl<V: Default> Trie<u8, V> {
     /// Puts a value in with a certain string key.
     /// The old value is ejected if it exists.
     pub fn put_str(&mut self, key: &str, val: V) -> Option<V> {
@@ -166,13 +160,13 @@ impl<V> Trie<u8, V> {
     }
 }
 
-impl<K: Eq + Clone, V> TrieNode<K, V> {
+impl<K: Eq + Clone + Default, V: Default> TrieNode<K, V> {
     fn size(&self) -> usize {
         let mut size = 1;
         for other in self.children.iter() {
             size += other.size();
         }
-        return size;
+        size
     }
 
     fn get(&self, key: &[K]) -> Option<&V> {
@@ -188,12 +182,9 @@ impl<K: Eq + Clone, V> TrieNode<K, V> {
     }
 
     fn leaf(&self, key: &[K]) -> Option<&Self> {
-        for node in self.children.iter() {
-            if key.starts_with(node.prefix.as_ref()) {
-                return Some(&node);
-            }
-        }
-        None
+        self.children
+            .iter()
+            .find(|&node| key.starts_with(node.prefix.as_ref()))
     }
 
     fn get_mut(&mut self, key: &[K]) -> Option<&mut V> {
@@ -209,12 +200,9 @@ impl<K: Eq + Clone, V> TrieNode<K, V> {
     }
 
     fn leaf_mut(&mut self, key: &[K]) -> Option<&mut Self> {
-        for node in self.children.iter_mut() {
-            if key.starts_with(&node.prefix) {
-                return Some(node);
-            }
-        }
-        None
+        self.children
+            .iter_mut()
+            .find(|node| key.starts_with(&node.prefix))
     }
 
     fn insert(&mut self, key: &[K], value: V) -> Option<V> {
@@ -224,15 +212,15 @@ impl<K: Eq + Clone, V> TrieNode<K, V> {
         let rest = &key[self.prefix.len()..];
         let leaf = self.leaf_mut(rest);
         // still longer than leaf, and leaf exists
-        if leaf.is_some() {
-            return leaf.unwrap().insert(rest, value);
+        if let Some(leaf) = leaf {
+            return leaf.insert(rest, value);
         }
         // shorter than a valid leaf split target
         let split = self.insert_split_target(rest);
         if split.is_some() {
             let (idx, node) = split.unwrap();
             let inject = TrieNode {
-                prefix: (&rest[(rest.len() - 1)..(node.prefix.len() - rest.len())])
+                prefix: (rest[(rest.len() - 1)..(node.prefix.len() - rest.len())])
                     .to_owned()
                     .into_boxed_slice(),
                 children: Vec::new(),
@@ -249,7 +237,7 @@ impl<K: Eq + Clone, V> TrieNode<K, V> {
             value: Some(value),
         };
         self.children.push(inject);
-        return None;
+        None
     }
 
     fn insert_split_target(&mut self, key: &[K]) -> Option<(usize, &mut Self)> {
@@ -271,10 +259,8 @@ impl<K: Eq + Clone, V> TrieNode<K, V> {
         // get leaf node
         let rest = &key[self.prefix.len()..];
         let leaf = self.leaf_mut(rest);
-        if leaf.is_none() {
-            // not found, bail
-            return None;
-        }
+        // bail if not found
+        leaf.as_ref()?;
         // unwrap it - this relies on local variable shadowing
         let leaf = leaf.unwrap();
         // leaf is not exact
@@ -328,7 +314,7 @@ impl<K: Eq + Clone, V> TrieNode<K, V> {
         // this only makes sense if we only have 1 node.
         assert!(self.children.len() == 1);
         // take the node from below
-        let taken = std::mem::replace(&mut self.children[0].children, Vec::new());
+        let taken = std::mem::take(&mut self.children[0].children);
         // remove the node we have
         let node = self.children.remove(0);
         // steal their prefix
@@ -349,8 +335,8 @@ mod tests {
     #[test]
     fn insertion_retrieval() {
         let mut trie = Trie::new();
-        let v1 = vec!["a", "ab", "ac", "b", "c", "abc", "abcde", "abced"];
-        let v2 = vec![1, 2, 3, 4, 5, 6, 7, 9];
+        let v1 = ["a", "ab", "ac", "b", "c", "abc", "abcde", "abced"];
+        let v2 = [1, 2, 3, 4, 5, 6, 7, 9];
         for i in 0..8 {
             trie.put_str(v1[i], v2[i]);
         }
@@ -366,8 +352,8 @@ mod tests {
     #[test]
     fn insertion_deletion() {
         let mut trie = Trie::new();
-        let v1 = vec!["a", "ab", "ac", "b", "c", "abc", "abcde", "abced"];
-        let v2 = vec![1, 2, 3, 4, 5, 6, 7, 9];
+        let v1 = ["a", "ab", "ac", "b", "c", "abc", "abcde", "abced"];
+        let v2 = [1, 2, 3, 4, 5, 6, 7, 9];
         for i in 0..8 {
             trie.put_str(v1[i], v2[i]);
         }
@@ -391,8 +377,18 @@ mod tests {
     #[test]
     fn i32_tests() {
         let mut trie = Trie::new();
-        let v1: Vec<Box<[i32]>> = vec![[1].into(), [2].into(), [3].into(), [4].into(), [2, 3, 4].into(), [2, 3, 4, 5].into(), [3, 5, 1].into(), [1, 11, 111].into(), [1, 111, 11].into()];
-        let v2 = vec!["a", "b", "c", "d", "e", "f", "g" ,"h", "i"];
+        let v1: Vec<Box<[i32]>> = vec![
+            [1].into(),
+            [2].into(),
+            [3].into(),
+            [4].into(),
+            [2, 3, 4].into(),
+            [2, 3, 4, 5].into(),
+            [3, 5, 1].into(),
+            [1, 11, 111].into(),
+            [1, 111, 11].into(),
+        ];
+        let v2 = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
         for i in 0..v1.len() {
             trie.put(v1[i].as_ref(), v2[i].to_owned());
         }


### PR DESCRIPTION
Hi @vargrind
I removed some clippy warnings and made some code more idiomatic.
I also added the Default trait as trait bounds for K and V.
In my opinion this is an acceptable restriction and makes the Trie::new function more terse. But I can revert the Default part easily.
Let me know whether I should revert the Default restriction.

I hope this is helpful.

I consider contributing more functionality like the missing support for iteration.